### PR TITLE
Add WP Custom Dashboard Widget Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,50 @@
 # WP Custom Dashboard Widget
 
-A WordPress plugin exercise to add a custom dashboard widget that displays motivational quotes and a welcome message. This is designed as a hands-on coding exercise where you will fork the repo, implement the plugin, and submit a Pull Request (PR).
+A WordPress plugin that adds a custom dashboard widget displaying motivational quotes and a welcome message. Includes a settings page and a shortcode for frontend display.
 
 ---
 
-## Problem Statement
+## Features
 
-Create a WordPress plugin that:
+1. *Dashboard Widget*
+   - Displays a welcome message with current date and time.
+   - Shows a random motivational quote.
 
-1. **Adds a Custom Dashboard Widget**  
-   - Display a welcome message with the current date and time.  
-   - Display a random motivational quote from a predefined array.  
+2. *Settings Page*
+   - Manage motivational quotes under *Settings → Dashboard Widget Settings*.
+   - Add, remove, or edit quotes.
 
-2. **Includes a Settings Page**  
-   - Add a submenu under **Settings → Dashboard Widget Settings**.  
-   - Allow the admin to add, remove, or edit quotes.  
-   - Save quotes using WordPress `options`.  
-
-3. **Provides a Shortcode**  
-   - `[dashboard_widget_message]` outputs the same welcome message and random quote on the frontend.  
-
-4. **Follows WordPress Best Practices**  
-   - Proper sanitization and escaping (`esc_html()`, `esc_attr()`).  
-   - Use WordPress hooks and functions correctly.  
+3. *Shortcode*
+   - [dashboard_widget_message] displays the welcome message and random quote on the frontend.
 
 ---
 
-## Instructions
+## Installation
 
-1. Fork this repository to your own GitHub account.  
-2. Clone your fork locally:  
-   ```bash
-   git clone https://github.com/YOUR_USERNAME/wp-custom-dashboard-widget.git
-   cd wp-custom-dashboard-widget
+1. Clone this repository or download the plugin file.
+2. Place wp-custom-dashboard-widget.php in your WordPress /wp-content/plugins/ directory.
+3. Activate the plugin in WordPress admin.
+
+---
+
+## Usage
+
+- *Dashboard:* See the custom widget in the admin dashboard.
+- *Shortcode:* Use [dashboard_widget_message] in posts/pages to display the message.
+- *Settings:* Update quotes from the settings page.
+
+---
+
+## Contribution
+
+1. Fork this repository.
+2. Implement the plugin features in wp-custom-dashboard-widget.php.
+3. Submit a Pull Request with your changes.
+
+---
+
+## Notes
+
+- All code should follow WordPress coding standards.
+- Proper sanitization applied (esc_html(), esc_attr()).
+- Aim for a single-file implementation (~150 lines).

--- a/wp-custom-dashboard-widget.php
+++ b/wp-custom-dashboard-widget.php
@@ -1,0 +1,121 @@
+<?php
+/*
+Plugin Name: WP Custom Dashboard Widget
+Description: Adds a custom dashboard widget and allows managing motivational quotes.
+Version: 1.0
+Author: Mohammed Khalid
+*/
+
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+
+class WP_Custom_Dashboard_Widget {
+
+    private $option_name = 'wp_cdw_quotes';
+
+    public function __construct() {
+        add_action('wp_dashboard_setup', [$this, 'add_dashboard_widget']);
+        add_action('admin_menu', [$this, 'add_settings_page']);
+        add_action('admin_init', [$this, 'register_settings']);
+        add_shortcode('dashboard_widget_message', [$this, 'shortcode_display']);
+    }
+
+    // Add Dashboard Widget
+    public function add_dashboard_widget() {
+        wp_add_dashboard_widget(
+            'wp_cdw_widget',
+            'Motivational Widget',
+            [$this, 'dashboard_widget_display']
+        );
+    }
+
+    // Dashboard Widget content
+    public function dashboard_widget_display() {
+        $quotes = get_option($this->option_name, $this->default_quotes());
+        $quote = $quotes[array_rand($quotes)];
+        $date = date_i18n('l, F j, Y, g:i a');
+
+        echo '<p><strong>Welcome!</strong></p>';
+        echo '<p>Today is: ' . esc_html($date) . '</p>';
+        echo '<p>Quote of the moment: <em>' . esc_html($quote) . '</em></p>';
+    }
+
+    // Shortcode output
+    public function shortcode_display() {
+        $quotes = get_option($this->option_name, $this->default_quotes());
+        $quote = $quotes[array_rand($quotes)];
+        $date = date_i18n('l, F j, Y, g:i a');
+
+        return '<p><strong>Welcome!</strong></p>' .
+               '<p>Today is: ' . esc_html($date) . '</p>' .
+               '<p>Quote of the moment: <em>' . esc_html($quote) . '</em></p>';
+    }
+
+    // Settings page
+    public function add_settings_page() {
+        add_options_page(
+            'Dashboard Widget Settings',
+            'Dashboard Widget',
+            'manage_options',
+            'wp-cdw-settings',
+            [$this, 'settings_page_html']
+        );
+    }
+
+    public function register_settings() {
+        register_setting('wp_cdw_settings_group', $this->option_name, [
+            'type' => 'array',
+            'sanitize_callback' => [$this, 'sanitize_quotes'],
+            'default' => $this->default_quotes(),
+        ]);
+    }
+
+    public function sanitize_quotes($input) {
+        $output = [];
+        if (is_array($input)) {
+            foreach ($input as $quote) {
+                $quote = sanitize_text_field($quote);
+                if (!empty($quote)) $output[] = $quote;
+            }
+        }
+        return $output;
+    }
+
+    // Settings page HTML
+    public function settings_page_html() {
+        if (!current_user_can('manage_options')) return;
+
+        $quotes = get_option($this->option_name, $this->default_quotes());
+        ?>
+        <div class="wrap">
+            <h1>Dashboard Widget Settings</h1>
+            <form method="post" action="options.php">
+                <?php settings_fields('wp_cdw_settings_group'); ?>
+                <table class="form-table">
+                    <tr valign="top">
+                        <th scope="row">Quotes</th>
+                        <td>
+                            <textarea name="<?php echo esc_attr($this->option_name); ?>[]" rows="10" cols="50" class="large-text"><?php echo esc_textarea(implode("\n", $quotes)); ?></textarea>
+                            <p class="description">Enter one quote per line.</p>
+                        </td>
+                    </tr>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+        </div>
+        <?php
+    }
+
+    // Default quotes
+    private function default_quotes() {
+        return [
+            "Believe in yourself!",
+            "Every day is a new beginning.",
+            "You are stronger than you think.",
+            "Stay positive, work hard, make it happen.",
+            "The best time for new beginnings is now."
+        ];
+    }
+
+}
+
+new WP_Custom_Dashboard_Widget();


### PR DESCRIPTION
### Summary
This PR adds the WP Custom Dashboard Widget plugin with the following features:

- Custom dashboard widget showing welcome message, date/time, and random quote.
- Settings page to manage quotes.
- Shortcode [dashboard_widget_message] for frontend display.
- Sanitization and WordPress best practices applied.

### How to Test
1. Clone this fork or download the plugin file.
2. Place wp-custom-dashboard-widget.php in /wp-content/plugins/.
3. Activate the plugin from WordPress admin.
4. Verify:
   - Dashboard widget appears with welcome message and random quote.
   - Shortcode outputs correctly on a page.
   - Settings page updates quotes correctly.
   
   
 closes: #1 